### PR TITLE
Frequency domain sub-sampling for strided convolution

### DIFF
--- a/fft_conv.py
+++ b/fft_conv.py
@@ -1,6 +1,5 @@
 from functools import partial
 from typing import Tuple, Union, Iterable
-import math
 
 import torch
 from torch import nn, Tensor

--- a/fft_conv.py
+++ b/fft_conv.py
@@ -4,7 +4,7 @@ import math
 
 import torch
 from torch import nn, Tensor
-from torch.fft import rfftn, irfftn, ifftn, fftn, fftshift, ifftshift, rfft, irfft, fft, ifft
+from torch.fft import rfftn, ifftn, irfft, ifft
 import torch.nn.functional as f
 from torch.nn.modules.utils import _reverse_repeat_tuple
 

--- a/fft_conv.py
+++ b/fft_conv.py
@@ -99,17 +99,12 @@ def fft_conv(
         signal_ = f.pad(signal, extra_padding)
     else:
         signal_ = signal
-    kernel_padding = [
-        pad
-        for i in reversed(range(2, signal_.ndim))
-        for pad in [0, signal_.size(i) - kernel.size(i)]
-    ]
-    padded_kernel = f.pad(kernel, kernel_padding)
 
     # Perform fourier convolution -- FFT, matrix multiply, then IFFT
     # signal_ = signal_.reshape(signal_.size(0), groups, -1, *signal_.shape[2:])
     signal_fr = rfftn(signal_, dim=tuple(range(2, signal.ndim)))
-    kernel_fr = rfftn(padded_kernel, dim=tuple(range(2, signal.ndim)))
+    kernel_fr = rfftn(
+        kernel, s=signal_.shape[2:], dim=tuple(range(2, signal.ndim)))
 
     output_fr = complex_matmul(signal_fr, kernel_fr.conj(), groups=groups)
 
@@ -186,12 +181,12 @@ class _FFTConv(nn.Module):
         self.groups = groups
         self.use_bias = bias
 
-        if in_channels % 2 != 0:
+        if in_channels % groups != 0:
             raise ValueError(
                 "'in_channels' must be divisible by 'groups'."
                 f"Found: in_channels={in_channels}, groups={groups}."
             )
-        if out_channels % 2 != 0:
+        if out_channels % groups != 0:
             raise ValueError(
                 "'out_channels' must be divisible by 'groups'."
                 f"Found: out_channels={out_channels}, groups={groups}."

--- a/fft_conv.py
+++ b/fft_conv.py
@@ -9,10 +9,6 @@ import torch.nn.functional as f
 from torch.nn.modules.utils import _reverse_repeat_tuple
 
 
-def lcm(a, b):
-    return abs(a*b) // math.gcd(a, b)
-
-
 def complex_matmul(a: Tensor, b: Tensor, groups: int = 1) -> Tensor:
     """Multiplies two complex-valued tensors."""
     # Scalar matrix multiplication of two tensors, over only the first channel


### PR DESCRIPTION
## Purpose

This PR handle strided convolution in frequency domain, in order to save more memory and computational resources.

## Details

Strided convolution is very similar to down-sampling the output signal without applying a low-pass filter in advance. In the frequency domain the original signal will become overlapped. This overlapping effect can be done easily as long as the signal length can be divided by stride.
Assume `X` is the frequency response of `x`. The frequency response of `x[::stride]` is actually equal to `X.view(stride, -1).mean(0)`

## Benefits In Theory:
* Memory: can be lower by a factor of `1 / np.product(strides)`
* Complexity: can be lower by a factor of `1 / np.product(strides)`

To validate these advantages, benchmarking or profiling is needed.