### PR TITLE
convert crop_slices to tuple

### DIFF
--- a/fft_conv_pytorch/fft_conv.py
+++ b/fft_conv_pytorch/fft_conv.py
@@ -132,11 +132,9 @@ def fft_conv(
     output = irfftn(output_fr, dim=tuple(range(2, signal.ndim)))
 
     # Remove extra padded values
-    crop_slices = tuple(
-        [slice(None), slice(None)] + [
-            slice(0, (signal_size[i] - kernel.size(i) + 1), stride_[i - 2])
-            for i in range(2, signal.ndim)
-        ]
+    crop_slices = (slice(None), slice(None)) + tuple(
+        slice(0, (signal_size[i] - kernel.size(i) + 1), stride_[i - 2])
+        for i in range(2, signal.ndim)
     )
     output = output[crop_slices].contiguous()
 

--- a/fft_conv_pytorch/fft_conv.py
+++ b/fft_conv_pytorch/fft_conv.py
@@ -132,10 +132,12 @@ def fft_conv(
     output = irfftn(output_fr, dim=tuple(range(2, signal.ndim)))
 
     # Remove extra padded values
-    crop_slices = [slice(None), slice(None)] + [
-        slice(0, (signal_size[i] - kernel.size(i) + 1), stride_[i - 2])
-        for i in range(2, signal.ndim)
-    ]
+    crop_slices = tuple(
+        [slice(None), slice(None)] + [
+            slice(0, (signal_size[i] - kernel.size(i) + 1), stride_[i - 2])
+            for i in range(2, signal.ndim)
+        ]
+    )
     output = output[crop_slices].contiguous()
 
     # Optionally, add a bias term before returning.


### PR DESCRIPTION
Hi! Thanks for your package, I have been using it as part of the batchgeneratorsv2 data augmentations pipeline, and I kept getting the following UserWarning:

`
/opt/homebrew/Caskroom/miniconda/base/envs/tm-torch/lib/python3.12/site-packages/fft_conv_pytorch/fft_conv.py:139: UserWarning: Using a non-tuple sequence for multidimensional indexing is deprecated and will be changed in pytorch 2.9; use x[tuple(seq)] instead of x[seq]. In pytorch 2.9 this will be interpreted as tensor index, x[torch.tensor(seq)], which will result either in an error or a different result (Triggered internally at /Users/runner/work/pytorch/pytorch/pytorch/torch/csrc/autograd/python_variable_indexing.cpp:312.)
`

I think that with the little change I've commited it should be fixed, but I haven't tested it! Although it's such a small change I don't think it can break anything.

UPDATE: I've tested it and it works same as before.